### PR TITLE
do not escape html in marshalled json output

### DIFF
--- a/internal/jobs/history.go
+++ b/internal/jobs/history.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/mimiro-io/datahub-cli/internal/api"
@@ -80,16 +81,18 @@ func getHistory(id string, server string, token string) api.JobHistory {
 }
 
 func renderHistory(history api.JobHistory, format string) {
-
-	jd, err := json.Marshal(history)
+	bf := bytes.NewBuffer([]byte{})
+	jsonEncoder := json.NewEncoder(bf)
+	jsonEncoder.SetEscapeHTML(false)
+	err := jsonEncoder.Encode(history)
 	utils.HandleError(err)
+	jd := bf.String()
 
 	switch format {
 	case "json":
-		fmt.Println(string(jd))
-	case "pretty":
+		fmt.Println(jd)
 	default:
-		p := pretty.Pretty(jd)
+		p := pretty.Pretty([]byte(jd))
 		result := pretty.Color(p, nil)
 		fmt.Println(string(result))
 	}


### PR DESCRIPTION
if error messages in `mim jobs history <id>` contained html, then the
chars `<`, `>` and `&` were escaped to unicode rune replacements.

This had a negative impact on readablility. With this change, these
characters stay unescaped in the resulting json strings.