### PR TITLE
Add success check for login and fix error handling

### DIFF
--- a/internal/login/use.go
+++ b/internal/login/use.go
@@ -104,7 +104,7 @@ func UseLogin(alias string) (*config.SignedToken, error) {
 	}
 
 	if err2 != nil {
-		return nil, err
+		return nil, err2
 	}
 
 	data.Type = loginType         // this will upgrade existing ones as they are used

--- a/internal/web/token.go
+++ b/internal/web/token.go
@@ -187,6 +187,12 @@ func DoAdminLogin(cfg *config.Config) (*config.SignedToken, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
+	statusOK := res.StatusCode >= 200 && res.StatusCode < 300
+	if !statusOK {
+		bodyBytes, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("%d: %s", res.StatusCode, string(bodyBytes))
+	}
 
 	decoder := json.NewDecoder(res.Body)
 	response := make(map[string]interface{})


### PR DESCRIPTION
Will now check for 2xx status code on admin login request
The wrong error variable was returned to the caller causing it to fail
silently

Fixes #105