### PR TITLE
Add support for multiple ids when creating datasets and clean up job api usage #111

### DIFF
--- a/internal/jobs/delete.go
+++ b/internal/jobs/delete.go
@@ -15,8 +15,6 @@
 package jobs
 
 import (
-	"fmt"
-	"github.com/mimiro-io/datahub-cli/internal/web"
 	"os"
 
 	"github.com/mimiro-io/datahub-cli/internal/api"
@@ -60,13 +58,15 @@ to quickly create a Cobra application.`,
 
 		pterm.EnableDebugMessages()
 
-		id := ResolveId(server, token, idOrTitle)
+		jm := api.NewJobManager(server, token)
+
+		id := jm.ResolveId(idOrTitle)
 		pterm.DefaultSection.Println("Deleting job with id: " + id + " (" + idOrTitle + ") ")
 
 		if confirm {
 			pterm.Warning.Printf("Delete job with job id: " + id + " (" + idOrTitle + ") on " + server + ", please type (y)es or (n)o and then press enter:")
 			if utils.AskForConfirmation() {
-				err = web.DeleteRequest(server, token, fmt.Sprintf("/jobs/%s", id))
+				err = jm.DeleteJob(id)
 				utils.HandleError(err)
 
 				pterm.Success.Println("Deleted job")
@@ -75,7 +75,7 @@ to quickly create a Cobra application.`,
 				pterm.Println("Aborted!")
 			}
 		} else {
-			err = web.DeleteRequest(server, token, fmt.Sprintf("/jobs/%s", id))
+			err = jm.DeleteJob(id)
 			utils.HandleError(err)
 
 			pterm.Success.Println("Deleted job")

--- a/internal/jobs/get.go
+++ b/internal/jobs/get.go
@@ -61,13 +61,12 @@ to quickly create a Cobra application.`,
 			pterm.Println()
 			os.Exit(1)
 		}
-		id := ResolveId(server,token, idOrTitle)
+		jm := api.NewJobManager(server, token)
+		id := jm.ResolveId(idOrTitle)
 
 		pterm.DefaultSection.Printf("Get description of job with id: " + id + " (" + idOrTitle + ") on " + server)
 
-		jobManager := api.NewJobManager(server, token)
-
-		job, err := jobManager.GetJob(id)
+		job, err := jm.GetJob(id)
 		utils.HandleError(err)
 
 		renderJob(job, format)

--- a/internal/jobs/history.go
+++ b/internal/jobs/history.go
@@ -21,7 +21,6 @@ import (
 	"github.com/mimiro-io/datahub-cli/internal/api"
 	"github.com/mimiro-io/datahub-cli/internal/login"
 	"github.com/mimiro-io/datahub-cli/internal/utils"
-	"github.com/mimiro-io/datahub-cli/internal/web"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
@@ -56,12 +55,12 @@ var HistoryCmd = &cobra.Command{
 			pterm.Println()
 			os.Exit(1)
 		}
-
-		id := ResolveId(server, token, idOrTitle)
+		jm := api.NewJobManager(server, token)
+		id := jm.ResolveId(idOrTitle)
 
 		pterm.DefaultSection.Printf("Get history of job with id: " + id + " (" + idOrTitle + ") on " + server)
 
-		hist := getHistory(id, server, token)
+		hist, err := jm.GetJobHistory(id)
 		utils.HandleError(err)
 
 		renderHistory(hist, format)
@@ -78,24 +77,6 @@ var HistoryCmd = &cobra.Command{
 
 func init() {
 	HistoryCmd.Flags().StringP("id", "i", "", "The name of the job you want to get status on")
-}
-
-func getHistory(id string, server string, token string) api.JobHistory {
-	endpoint := "/jobs/_/history"
-
-	body, err := web.GetRequest(server, token, endpoint)
-	utils.HandleError(err)
-
-	histories := make([]api.JobHistory, 0)
-	err = json.Unmarshal(body, &histories)
-	utils.HandleError(err)
-
-	for _, hist := range histories {
-		if hist.Id == id {
-			return hist
-		}
-	}
-	return api.JobHistory{}
 }
 
 func renderHistory(history api.JobHistory, format string) {

--- a/internal/jobs/list.go
+++ b/internal/jobs/list.go
@@ -447,28 +447,6 @@ func listJobs(jobs []byte, history []byte) ([]api.JobOutput, error) {
 	return output, nil
 }
 
-func ResolveId(server string, token string, title string) string {
-	id := title
-	allJobs, err := web.GetRequest(server, token, "/jobs")
-	utils.HandleError(err)
-
-	joblist := &[]api.Job{}
-	err = json.Unmarshal(allJobs, joblist)
-	if err != nil {
-		return title
-	}
-
-	for _, job := range *joblist {
-		out := api.JobOutput{
-			Job: job,
-		}
-		if out.Job.Title == title {
-			id = out.Job.Id
-		}
-	}
-	return id
-}
-
 func init() {
 	ListCmd.PersistentFlags().Bool("verbose", false, "Verbose output of jobs list")
 	ListCmd.PersistentFlags().StringP("filter", "", "", "Filter job list with a filter query i.e  'tags=foo,bar' or 'title=foo,bar'. Combine filters by filters with ';' i.e. 'tags=foo;title=bar'")

--- a/internal/jobs/operate.go
+++ b/internal/jobs/operate.go
@@ -71,7 +71,7 @@ to quickly create a Cobra application.`,
 		pterm.Println()
 		if operation == "run" {
 			// is job running?
-			running, err := getStatus(id, server, token)
+			running, err := jm.GetJobStatus(id)
 			utils.HandleError(err)
 			runningId := ""
 			if len(running) == 0 { // not running
@@ -96,7 +96,7 @@ to quickly create a Cobra application.`,
 			}
 
 			// follow the job
-			err = followJob(runningId, server, token)
+			err = followJob(runningId, *jm)
 			utils.HandleError(err)
 		} else if operation == "pause" {
 			_, err = web.PutRequest(server, token, fmt.Sprintf("/job/%s/pause", id))
@@ -154,14 +154,14 @@ func getJobResponse(response []byte) (*jobResponse, error) {
 	return job, nil
 }
 
-func followJob(jobId, server string, token string) error {
+func followJob(jobId string, jm api.JobManager) error {
 	pterm.Println()
 	spinner, err := pterm.DefaultSpinner.Start(fmt.Sprintf("Processing job with id '%s'", jobId))
 	utils.HandleError(err)
 	success := true
 	msg := "Finished"
 	for {
-		status, err := getStatus(jobId, server, token)
+		status, err := jm.GetJobStatus(jobId)
 		if err != nil {
 			success = false
 			msg = err.Error()

--- a/internal/jobs/operate.go
+++ b/internal/jobs/operate.go
@@ -64,7 +64,8 @@ to quickly create a Cobra application.`,
 		since, err := cmd.Flags().GetString("since")
 		utils.HandleError(err)
 
-		id := ResolveId(server, token, idOrTitle)
+		jm := api.NewJobManager(server, token)
+		id := jm.ResolveId(idOrTitle)
 
 		pterm.DefaultSection.Printf("Execute operation " + operation + " on job with id: " + id + " (" + idOrTitle + ") on " + server)
 		pterm.Println()

--- a/internal/jobs/status.go
+++ b/internal/jobs/status.go
@@ -63,14 +63,16 @@ mim jobs status
 
 		var id string
 
+		jm := api.NewJobManager(server, token)
+
 		if idOrTitle != "" {
-			id = ResolveId(server, token, idOrTitle)
+			id = jm.ResolveId(idOrTitle)
 			pterm.DefaultSection.Printf("Get status on job with job id: " + id + " (" + idOrTitle + ") on " + server)
 		} else {
 			pterm.DefaultSection.Printf("Get status on all running jobs on " + server)
 			id = ""
 		}
-		jobs, err := getStatus(id, server, token)
+		jobs, err := jm.GetJobStatus(id)
 		utils.HandleError(err)
 
 		renderBody(jobs, format)
@@ -109,7 +111,7 @@ func getStatus(id string, server string, token string) ([]jobStatus, error) {
 	return jobs, nil
 }
 
-func renderBody(jobs []jobStatus, format string) {
+func renderBody(jobs []api.JobStatus, format string) {
 
 	jd, err := json.Marshal(jobs)
 	utils.HandleError(err)

--- a/internal/jobs/status.go
+++ b/internal/jobs/status.go
@@ -17,7 +17,6 @@ package jobs
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mimiro-io/datahub-cli/internal/web"
 	"time"
 
 	"github.com/mimiro-io/datahub-cli/internal/api"
@@ -89,26 +88,6 @@ mim jobs status
 
 func init() {
 	StatusCmd.Flags().StringP("id", "i", "", "The name of the job you want to get status on")
-}
-
-func getStatus(id string, server string, token string) ([]jobStatus, error) {
-	endpoint := "/jobs/_/status"
-	if id != "" {
-		endpoint = fmt.Sprintf("/job/%s/status", id)
-	}
-
-	body, err := web.GetRequest(server, token, endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	jobs := make([]jobStatus, 0)
-	err = json.Unmarshal(body, &jobs)
-	if err != nil {
-		return nil, err
-	}
-
-	return jobs, nil
 }
 
 func renderBody(jobs []api.JobStatus, format string) {


### PR DESCRIPTION
This is only part of the work to add support for using multiple ids when running certain job operations. Part of #111 