### PR TITLE
feature_130: fix error handling on mim job add

### DIFF
--- a/internal/jobs/add.go
+++ b/internal/jobs/add.go
@@ -15,12 +15,14 @@
 package jobs
 
 import (
+	"fmt"
 	"github.com/mimiro-io/datahub-cli/internal/api"
 	"github.com/mimiro-io/datahub-cli/internal/login"
 	"github.com/mimiro-io/datahub-cli/internal/transform"
 	"github.com/mimiro-io/datahub-cli/internal/utils"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"os"
 	"path/filepath"
 )
 
@@ -55,11 +57,6 @@ to quickly create a Cobra application.`,
 		pterm.Success.Println("Read config file")
 
 		jobManager := api.NewJobManager(server, token)
-		job, err := jobManager.AddJob(config)
-
-		utils.HandleError(err)
-
-		pterm.Success.Println("Added job to server")
 
 		tfile, err := cmd.Flags().GetString("transform")
 
@@ -72,8 +69,22 @@ to quickly create a Cobra application.`,
 				code, err = importer.ImportJs()
 			}
 			utils.HandleError(err)
+
+			job, err := jobManager.AddJob(config)
+			utils.HandleError(err)
+			pterm.Success.Println("Added job to server")
+
 			job, err = jobManager.AddTransform(job, importer.Encode(code))
+			if (err != nil){
+				pterm.Error.Println(fmt.Sprintf("Could not add Transform to job. Response from datahub was: %s", err))
+				pterm.Println()
+				os.Exit(1)
+			}
 			pterm.Success.Println("Added transform to job")
+		} else {
+			_, err := jobManager.AddJob(config)
+			utils.HandleError(err)
+			pterm.Success.Println("Added job to server")
 		}
 
 		pterm.Println()

--- a/internal/jobs/add.go
+++ b/internal/jobs/add.go
@@ -57,6 +57,11 @@ to quickly create a Cobra application.`,
 		pterm.Success.Println("Read config file")
 
 		jobManager := api.NewJobManager(server, token)
+		job, err := jobManager.AddJob(config)
+
+		utils.HandleError(err)
+
+		pterm.Success.Println("Added job to server")
 
 		tfile, err := cmd.Flags().GetString("transform")
 
@@ -70,10 +75,6 @@ to quickly create a Cobra application.`,
 			}
 			utils.HandleError(err)
 
-			job, err := jobManager.AddJob(config)
-			utils.HandleError(err)
-			pterm.Success.Println("Added job to server")
-
 			job, err = jobManager.AddTransform(job, importer.Encode(code))
 			if (err != nil){
 				pterm.Error.Println(fmt.Sprintf("Could not add Transform to job. Response from datahub was: %s", err))
@@ -81,10 +82,6 @@ to quickly create a Cobra application.`,
 				os.Exit(1)
 			}
 			pterm.Success.Println("Added transform to job")
-		} else {
-			_, err := jobManager.AddJob(config)
-			utils.HandleError(err)
-			pterm.Success.Println("Added job to server")
 		}
 
 		pterm.Println()


### PR DESCRIPTION
Closes: #130 
Output error generated in the datahub and exit mim if jobs do not get added correctly.