### PR TITLE
[BUGFIX] Bad name parameter handling

### DIFF
--- a/internal/command/datasets.go
+++ b/internal/command/datasets.go
@@ -50,7 +50,7 @@ func init() {
 	DatasetCmd.AddCommand(datasets.EntitiesCmd)
 	DatasetCmd.AddCommand(datasets.ChangesCmd)
 	DatasetCmd.AddCommand(datasets.DeleteCmd)
-	DatasetCmd.AddCommand(datasets.CreateCmd)
+	DatasetCmd.AddCommand(datasets.CreateCmd())
 	DatasetCmd.AddCommand(datasets.GetCmd)
 	DatasetCmd.AddCommand(datasets.StoreCmd)
 	DatasetCmd.AddCommand(datasets.RenameCmd)


### PR DESCRIPTION
When the --name parameter was given, and --proxy true was also given, a missing check in the existence of name lead to "true" from --proxy to be set as the name of the dataset to be created.

By moving the check higher up in the code, and only attempt to read from args if name was empty, this bug is fixed.

The code has also been refactored to use a func pattern instead of the existing pattern. This allows for clean separation of variables between command's and also allows to remove err checks when reading params. Param reading is now fully handled by the cobra framework.