### PR TITLE
[FEATURE] Allow job operate on multiple job ids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -468,6 +468,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/command/jobs.go
+++ b/internal/command/jobs.go
@@ -52,7 +52,7 @@ func init() {
 	JobsCmd.AddCommand(jobs.GetCmd)
 	JobsCmd.AddCommand(jobs.AddCmd)
 	JobsCmd.AddCommand(jobs.DeleteCmd)
-	JobsCmd.AddCommand(jobs.OperateCmd)
+	JobsCmd.AddCommand(jobs.CmdOperate())
 	JobsCmd.AddCommand(jobs.StatusCmd)
 	JobsCmd.AddCommand(jobs.HistoryCmd)
 

--- a/internal/utils/renderkit.go
+++ b/internal/utils/renderkit.go
@@ -1,0 +1,14 @@
+package utils
+
+import "time"
+
+var (
+	// load up some variables used for formatting dates
+	loc, _ = time.LoadLocation("Local")
+	format = "2006-01-02 15:04:05"
+)
+
+func Date(dt time.Time) string {
+	localTime := dt.In(loc)
+	return localTime.Format(format)
+}

--- a/pkg/api/job.go
+++ b/pkg/api/job.go
@@ -78,14 +78,21 @@ type HistoryView struct {
 }
 
 type JobManager struct {
-	server string
-	token  string
+	server  string
+	token   string
+	Operate *JobOperation
+}
+
+type JobId struct {
+	Title string
+	Id    string
 }
 
 func NewJobManager(server string, token string) *JobManager {
 	return &JobManager{
-		server: server,
-		token:  token,
+		server:  server,
+		token:   token,
+		Operate: NewJobOperation(server, token),
 	}
 }
 
@@ -222,14 +229,36 @@ func GetJobsCompletion(pattern string) []string {
 }
 
 func (jm *JobManager) ResolveId(title string) string {
+	id := jm.ResolveIds([]string{title}...)[0] // should be ok as we always return the title if id not found
+	return id.Id
+}
+
+func (jm *JobManager) ResolveIds(titles ...string) []JobId {
 	jobList := jm.GetJobs()
 
-	for _, job := range jobList {
-		if job.Title == title {
-			return job.Id
+	ids := make([]JobId, 0)
+	for _, title := range titles {
+		found := false
+		for _, job := range jobList {
+			if job.Title == title {
+				ids = append(ids, JobId{
+					Title: job.Title,
+					Id:    job.Id,
+				})
+				found = true
+				break
+			}
+
 		}
+		if !found {
+			ids = append(ids, JobId{
+				Title: title,
+				Id:    title,
+			})
+		}
+		found = false
 	}
-	return title
+	return ids
 }
 
 func (jm *JobManager) GetJobs() []Job {

--- a/pkg/api/job_operate.go
+++ b/pkg/api/job_operate.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/mimiro-io/datahub-cli/internal/web"
+)
+
+type JobOperation struct {
+	server string
+	token  string
+}
+
+type JobOperationResponse struct {
+	JobId string `json:"jobId"`
+}
+
+// NewJobOperation will return a new JobOperation service. If you are already using the JobManager, then
+// this will have been initiated for you already, and you can call jm.Operate.XX.
+// Note that all methods take an ignored context, these should be refactored later together with a rework of the
+// http clients, as they are a bit all over the place.
+func NewJobOperation(server string, token string) *JobOperation {
+	return &JobOperation{server: server, token: token}
+}
+
+// Pause will pause the operation of a job
+func (o *JobOperation) Pause(_ context.Context, jobId string) (JobOperationResponse, error) {
+	return web.Put[JobOperationResponse](o.server, o.token, fmt.Sprintf("/job/%s/pause", jobId))
+}
+
+// Resume will resume a paused job
+func (o *JobOperation) Resume(_ context.Context, jobId string) (JobOperationResponse, error) {
+	return web.Put[JobOperationResponse](o.server, o.token, fmt.Sprintf("/job/%s/resume", jobId))
+}
+
+// Reset will reset the since tokens on a job, running the job from the start of the dataset
+func (o *JobOperation) Reset(_ context.Context, jobId string, since string) (JobOperationResponse, error) {
+	endpoint := fmt.Sprintf("/job/%s/reset", jobId)
+	if since != "" {
+		endpoint = "?since=" + since
+	}
+
+	return web.Put[JobOperationResponse](o.server, o.token, endpoint)
+}
+
+// Kill will attempt to stop an already running job
+func (o *JobOperation) Kill(_ context.Context, jobId string) (JobOperationResponse, error) {
+	return web.Put[JobOperationResponse](o.server, o.token, fmt.Sprintf("/job/%s/kill", jobId))
+}
+
+// Run will attempt to manually start a job
+func (o *JobOperation) Run(_ context.Context, jobId string, jobType string) (JobOperationResponse, error) {
+	endpoint := fmt.Sprintf("/job/%s/run", jobId)
+	if jobType != "" {
+		endpoint = endpoint + "?jobType=" + jobType
+	}
+	return web.Put[JobOperationResponse](o.server, o.token, endpoint)
+}
+
+// Test is just for testing and will always fail
+func (o *JobOperation) Test(_ context.Context, jobId string) (JobOperationResponse, error) {
+	return web.Put[JobOperationResponse](o.server, o.token, fmt.Sprintf("/job/%s/testx", jobId))
+}


### PR DESCRIPTION
When you want to enable or disable or do any other operation on jobs that involves more than 1 job, you have a lot of extra work to do today. This change allows to input multiple ids as input to job operate.

Example:
```bash
mim jobs operate -o run \
    --id proxy-cima-production-to-local \
    --id renewing-slayback \
    --id sacred-lionheart
```

The only exception is if you run a job with -w (follow) set, then you can only give 1 id. This is because of the ui differences between this and the other operations. These differences can be worked out for sure, but is not in scope for this change.

The api.JobManager has been extended with an Operate service that contains the methods for job operations.

The web client has been extended with web.Get[T any]() and web.Put[T any]() to make it easier to parse result from http calls into structs. I only added these, as the web client(s) can really benefit from a full refactor to get it under control.

I also added a "renderkit" file under utils, this is intended to keep functions used to render the ui, for now it just contains a utils.Date() func that formats a date to local timezone.