### PR TITLE
Add pkg/transform: public library for running transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ internal/command/VERSION
 
 # macOS
 .DS_Store
+
+CLAUDE.md

--- a/pkg/transform/client.go
+++ b/pkg/transform/client.go
@@ -1,0 +1,205 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/mimiro-io/datahub-cli/pkg/api"
+)
+
+type queryClient struct {
+	baseURL string
+	bearer  string
+	client  *http.Client
+}
+
+func newQueryClient(baseURL, bearer string) *queryClient {
+	return &queryClient{
+		baseURL: baseURL,
+		bearer:  bearer,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// queryResultPart decodes the [uri, predicateUri, entity] tuple from /query.
+type queryResultPart struct {
+	Uri          string
+	PredicateUri string
+	Entity       *api.Entity
+}
+
+func (p *queryResultPart) UnmarshalJSON(data []byte) error {
+	var v []json.RawMessage
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if len(v) < 3 {
+		return errors.New("query result tuple too short")
+	}
+	if err := json.Unmarshal(v[0], &p.Uri); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(v[1], &p.PredicateUri); err != nil {
+		return err
+	}
+	if string(v[2]) == "null" {
+		p.Entity = nil
+		return nil
+	}
+	ent := &api.Entity{}
+	if err := json.Unmarshal(v[2], ent); err != nil {
+		return err
+	}
+	p.Entity = ent
+	return nil
+}
+
+func (c *queryClient) Query(startingEntities []string, predicate string, inverse bool, datasets []string) ([]queryResultPart, error) {
+	if predicate == "" {
+		predicate = "*"
+	}
+	body := map[string]interface{}{
+		"startingEntities": startingEntities,
+		"predicate":        predicate,
+		"inverse":          inverse,
+		"datasets":         datasets,
+	}
+
+	raw, err := c.postJSON("/query", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope []json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode /query envelope: %w", err)
+	}
+	if len(envelope) < 2 {
+		return nil, errors.New("/query: empty response")
+	}
+
+	var parts []queryResultPart
+	if err := json.Unmarshal(envelope[1], &parts); err != nil {
+		return nil, fmt.Errorf("decode /query tuples: %w", err)
+	}
+	return parts, nil
+}
+
+func (c *queryClient) QuerySingle(entityId string, datasets []string) (*api.Entity, error) {
+	body := map[string]interface{}{
+		"entityId": entityId,
+		"datasets": datasets,
+	}
+
+	raw, err := c.postJSON("/query", body)
+	if err != nil {
+		return nil, err
+	}
+
+	entities := make([]api.Entity, 0)
+	if err := json.Unmarshal(raw, &entities); err != nil {
+		return nil, fmt.Errorf("decode /query single: %w", err)
+	}
+	if len(entities) < 2 {
+		return nil, errors.New("/query single: unexpected response")
+	}
+	return &entities[1], nil
+}
+
+type namespaceLookup struct {
+	Prefix    string `json:"prefix"`
+	Expansion string `json:"expansion"`
+}
+
+func (c *queryClient) GetNamespacePrefix(urlExpansion string) (string, error) {
+	path := fmt.Sprintf("/query/namespace?expansion=%s", url.QueryEscape(urlExpansion))
+	raw, err := c.get(path)
+	if err != nil {
+		return "", err
+	}
+	n := &namespaceLookup{}
+	if err := json.Unmarshal(raw, n); err != nil {
+		return "", err
+	}
+	return n.Prefix, nil
+}
+
+// Used at startup so AssertNamespacePrefix reuses existing prefixes rather than minting ns* names.
+func fetchNamespaces(baseURL, bearer string) (map[string]string, error) {
+	c := newQueryClient(baseURL, bearer)
+	raw, err := c.get("/namespaces")
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) postJSON(path string, body interface{}) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return c.do("POST", path, bytes.NewReader(payload), "application/json")
+}
+
+func (c *queryClient) get(path string) ([]byte, error) {
+	return c.do("GET", path, nil, "")
+}
+
+func (c *queryClient) do(method, path string, body io.Reader, contentType string) ([]byte, error) {
+	if c.baseURL == "" {
+		return nil, errors.New("transform: HubURL is required for hub-bound helpers")
+	}
+	req, err := http.NewRequest(method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	req.Header.Set("User-Agent", "datahub-pkg-transform/1.0")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		return raw, nil
+	}
+	msg := map[string]interface{}{}
+	if json.Unmarshal(raw, &msg) == nil {
+		if m, ok := msg["message"].(string); ok && m != "" {
+			return nil, fmt.Errorf("hub %s: %s", resp.Status, m)
+		}
+	}
+	return nil, fmt.Errorf("hub %s", resp.Status)
+}

--- a/pkg/transform/compile.go
+++ b/pkg/transform/compile.go
@@ -1,0 +1,157 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	esbuild "github.com/evanw/esbuild/pkg/api"
+)
+
+// goja can't parse import/export, so we strip module syntax after esbuild
+// emits ES2016. Host functions are injected as globals; datahub-tslib is
+// ambient-`declare` only, so no module wiring is needed at runtime.
+func compile(source string) (string, error) {
+	result := esbuild.Transform(source, esbuild.TransformOptions{
+		Loader: esbuild.LoaderTS,
+		Format: esbuild.FormatDefault,
+		Target: esbuild.ES2016,
+	})
+
+	if len(result.Errors) > 0 {
+		var msgs []string
+		for _, e := range result.Errors {
+			msgs = append(msgs, formatDiagnostic(e))
+		}
+		return "", errors.New(strings.Join(msgs, "\n"))
+	}
+
+	raw := string(result.Code)
+	aliases := detectTslibNamespaceAliases(raw)
+	stripped := stripImportsExports(raw)
+	if len(aliases) > 0 {
+		return buildNamespaceShim(aliases) + "\n" + stripped, nil
+	}
+	return stripped, nil
+}
+
+// Named imports already resolve to globals once stripped; only namespace
+// aliases (`import * as dh from "datahub-tslib"`) need a shim.
+func detectTslibNamespaceAliases(code string) []string {
+	var out []string
+	for _, line := range strings.Split(code, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "import") {
+			continue
+		}
+		if !strings.Contains(trimmed, "datahub-tslib") {
+			continue
+		}
+		idx := strings.Index(trimmed, "* as ")
+		if idx < 0 {
+			continue
+		}
+		rest := trimmed[idx+len("* as "):]
+		end := 0
+		for end < len(rest) && isIdentChar(rest[end]) {
+			end++
+		}
+		if end == 0 {
+			continue
+		}
+		out = append(out, rest[:end])
+	}
+	return out
+}
+
+func isIdentChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '_' || b == '$'
+}
+
+// Keep in lockstep with runtime.go::hookEngine and js_helpers.go::helperJavascriptFunctions.
+var nsShimMembers = []string{
+	"Query", "FindById", "GetNamespacePrefix", "AssertNamespacePrefix",
+	"Log", "NewEntity", "IsValidEntity", "ToString", "AsEntity", "UUID",
+	"SetProperty", "GetProperty", "GetReference", "AddReference",
+	"GetId", "SetId", "GetDeleted", "SetDeleted", "PrefixField",
+	"RenameProperty", "RemoveProperty", "NewEntityFrom",
+}
+
+func buildNamespaceShim(aliases []string) string {
+	var b strings.Builder
+	for _, alias := range aliases {
+		b.WriteString("var ")
+		b.WriteString(alias)
+		b.WriteString(" = {")
+		for i, m := range nsShimMembers {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(m)
+			b.WriteByte(':')
+			b.WriteString(m)
+		}
+		b.WriteString("};\n")
+	}
+	return b.String()
+}
+
+// Line-based strip of top-level ES module syntax. Relies on esbuild's
+// Transform canonicalising multi-line imports to a single line.
+func stripImportsExports(code string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(code, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "import ") ||
+			strings.HasPrefix(trimmed, "import{") ||
+			strings.HasPrefix(trimmed, "import\"") ||
+			strings.HasPrefix(trimmed, "import'") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "export default ") {
+			rest := strings.TrimPrefix(trimmed, "export default ")
+			if strings.HasPrefix(rest, "function ") ||
+				strings.HasPrefix(rest, "function(") ||
+				strings.HasPrefix(rest, "class ") ||
+				strings.HasPrefix(rest, "class{") ||
+				strings.HasPrefix(rest, "async ") {
+				b.WriteString(rest)
+				b.WriteByte('\n')
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "export ") {
+			rest := strings.TrimPrefix(trimmed, "export ")
+			if strings.HasPrefix(rest, "{") || strings.HasPrefix(rest, "*") {
+				continue
+			}
+			b.WriteString(rest)
+			b.WriteByte('\n')
+			continue
+		}
+		if trimmed == "export{}" || trimmed == "export {}" || trimmed == "export {};" || trimmed == "export{};" {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatDiagnostic(m esbuild.Message) string {
+	if m.Location != nil {
+		return fmt.Sprintf("[%d:%d] %s", m.Location.Line, m.Location.Column, m.Text)
+	}
+	return m.Text
+}

--- a/pkg/transform/compile_test.go
+++ b/pkg/transform/compile_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mimiro-io/datahub-cli/pkg/api"
+)
+
+func TestStripImportsExports(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "single import line dropped",
+			in:   "import { Entity } from \"datahub-tslib\";\nfunction f() { return 1; }",
+			want: "function f() { return 1; }",
+		},
+		{
+			name: "import \"side-effect\" dropped",
+			in:   "import \"./bootstrap\";\nfunction f() {}",
+			want: "function f() {}",
+		},
+		{
+			name: "export keyword stripped from function",
+			in:   "export function transform_entities(e) { return e; }",
+			want: "function transform_entities(e) { return e; }",
+		},
+		{
+			name: "export keyword stripped from const",
+			in:   "export const X = 1;",
+			want: "const X = 1;",
+		},
+		{
+			name: "export default expr dropped entirely",
+			in:   "export default 42;",
+			want: "",
+		},
+		{
+			name: "export default function unwrapped",
+			in:   "export default function f() { return 1; }",
+			want: "function f() { return 1; }",
+		},
+		{
+			name: "export { x, y } dropped",
+			in:   "function f() {}\nexport { f };",
+			want: "function f() {}",
+		},
+		{
+			name: "export * from \"x\" dropped",
+			in:   "export * from \"./other\";\nfunction f() {}",
+			want: "function f() {}",
+		},
+		{
+			name: "indented `export` keyword inside object literal preserved",
+			in: `const o = {
+  export: 1,
+};`,
+			want: `const o = {
+  export: 1,
+};`,
+		},
+		{
+			name: "no top-level module syntax — passthrough",
+			in:   "function f() { return 1; }",
+			want: "function f() { return 1; }",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripImportsExports(c.in)
+			if got != c.want {
+				t.Errorf("stripImportsExports() mismatch\nGOT:\n%s\nWANT:\n%s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRun_StripsImportSyntaxBeforeRunning(t *testing.T) {
+	src := `
+		import { Entity, Query, NewEntity } from "datahub-tslib";
+
+		export function transform_entities(entities: Entity[]) {
+			return entities.map((e) => {
+				const n = NewEntity();
+				SetId(n, GetId(e));
+				return n;
+			});
+		}
+	`
+	in := []*api.Entity{
+		{ID: "x:1", Properties: map[string]any{}, References: map[string]any{}},
+	}
+
+	res, err := Run(context.Background(), src, in, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, l := range res.Logs {
+		if l.Level == "error" {
+			t.Fatalf("unexpected error log entry: %+v", l)
+		}
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 entity, got %d", len(res.Entities))
+	}
+	if res.Entities[0].ID != "x:1" {
+		t.Errorf("ID = %q, want x:1", res.Entities[0].ID)
+	}
+}
+
+func TestRun_BareExportFunctionRuns(t *testing.T) {
+	src := `
+		export function transform_entities(entities: any[]) {
+			return entities;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "a", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, l := range res.Logs {
+		if l.Level == "error" {
+			t.Fatalf("unexpected error: %s", l.Message)
+		}
+	}
+	if len(res.Entities) != 1 || res.Entities[0].ID != "a" {
+		t.Errorf("got %+v", res.Entities)
+	}
+}
+
+func TestRun_NamespaceImportAliasResolvesAllMembers(t *testing.T) {
+	src := `
+		import * as dh from "datahub-tslib/datahub";
+
+		export function transform_entities(entities: dh.Entity[]): dh.Entity[] {
+			const ns = dh.AssertNamespacePrefix("http://example.org/");
+			let out: dh.Entity[] = [];
+			entities.forEach((e: dh.Entity) => {
+				let n = dh.NewEntityFrom(e, false, false, false);
+				dh.SetId(n, dh.GetId(e));
+				dh.AddReference(n, ns, "ref", "ns0:thing");
+				dh.SetProperty(n, ns, "prop", 42);
+				out.push(n);
+			});
+			return out;
+		}
+	`
+	in := []*api.Entity{
+		{ID: "x:1", Properties: map[string]any{}, References: map[string]any{}},
+		{ID: "x:2", Properties: map[string]any{}, References: map[string]any{}},
+	}
+
+	res, err := Run(context.Background(), src, in, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, l := range res.Logs {
+		if l.Level == "error" {
+			t.Fatalf("unexpected error log: %s", l.Message)
+		}
+	}
+	if len(res.Entities) != 2 {
+		t.Fatalf("want 2 entities, got %d", len(res.Entities))
+	}
+	if res.Entities[0].ID != "x:1" || res.Entities[1].ID != "x:2" {
+		t.Errorf("ids = %s, %s; want x:1, x:2", res.Entities[0].ID, res.Entities[1].ID)
+	}
+	hasRef := false
+	for _, v := range res.Entities[0].References {
+		if v == "ns0:thing" {
+			hasRef = true
+		}
+	}
+	if !hasRef {
+		t.Errorf("entity[0].References = %+v; want one entry with value ns0:thing", res.Entities[0].References)
+	}
+}
+
+func TestDetectTslibNamespaceAliases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "datahub-tslib root",
+			in:   `import * as dh from "datahub-tslib";`,
+			want: []string{"dh"},
+		},
+		{
+			name: "datahub-tslib/datahub",
+			in:   `import * as dh from "datahub-tslib/datahub";`,
+			want: []string{"dh"},
+		},
+		{
+			name: "ignores non-tslib namespace imports",
+			in:   `import * as fs from "node:fs";`,
+			want: nil,
+		},
+		{
+			name: "multiple aliases captured",
+			in:   "import * as dh from \"datahub-tslib\";\nimport * as ns2 from \"datahub-tslib/datahub\";",
+			want: []string{"dh", "ns2"},
+		},
+		{
+			name: "named imports do not produce aliases",
+			in:   `import { Query } from "datahub-tslib";`,
+			want: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := detectTslibNamespaceAliases(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("aliases[%d] = %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCompile_RealSyntaxErrorStillSurfaces(t *testing.T) {
+	src := "function transform_entities(entities"
+	res, err := Run(context.Background(), src, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Logs) == 0 || res.Logs[0].Level != "error" {
+		t.Fatalf("want error log entry, got %+v", res.Logs)
+	}
+	if !strings.Contains(strings.ToLower(res.Logs[0].Message), "expected") {
+		t.Errorf("error message %q doesn't look like an esbuild parse error", res.Logs[0].Message)
+	}
+}

--- a/pkg/transform/js_helpers.go
+++ b/pkg/transform/js_helpers.go
@@ -1,0 +1,133 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+const wrapperJavascriptFunction = `
+function transform_entities_ex(entities) {
+	try {
+		return transform_entities(entities);
+	} catch (e) {
+		throw(e);
+	}
+}
+`
+
+const helperJavascriptFunctions = `
+function SetProperty(entity, prefix, name, value) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	if (entity.Properties === null || entity.Properties === undefined) {
+		return;
+	}
+	entity["Properties"][prefix+":"+name] = value;
+}
+function GetProperty(entity, prefix, name, defaultValue) {
+	if (entity === null || entity === undefined) {
+		return defaultValue;
+	}
+	if (entity.Properties === null || entity.Properties === undefined) {
+		return defaultValue;
+	}
+	var value = entity["Properties"][prefix+":"+name]
+	if (value === undefined || value === null) {
+		return defaultValue;
+	}
+	return value;
+}
+function GetReference(entity, prefix, name, defaultValue) {
+	if (entity === null || entity === undefined) {
+		return defaultValue;
+	}
+	if (entity.References === null || entity.References === undefined) {
+		return defaultValue;
+	}
+	var value = entity["References"][prefix+":"+name]
+	if (value === undefined || value === null) {
+		return defaultValue;
+	}
+	return value;
+}
+function AddReference(entity, prefix, name, value) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	if (entity.References === null || entity.References === undefined) {
+		return;
+	}
+	entity["References"][prefix+":"+name] = value;
+}
+function GetId(entity) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	return entity["ID"];
+}
+function SetId(entity, id) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	entity.ID = id
+}
+function SetDeleted(entity, deleted) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	entity.IsDeleted = deleted
+}
+function GetDeleted(entity) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	return entity.IsDeleted;
+}
+function PrefixField(prefix, field) {
+	return prefix + ":" + field;
+}
+function RenameProperty(entity, originalPrefix, originalName, newPrefix, newName) {
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	var value = GetProperty(entity, originalPrefix, originalName);
+	SetProperty(entity, newPrefix, newName, value);
+	RemoveProperty(entity, originalPrefix, originalName);
+}
+function RemoveProperty(entity, prefix, name){
+	if (entity === null || entity === undefined) {
+		return;
+	}
+	delete entity["Properties"][prefix+":"+name];
+}
+function NewEntityFrom(entity, addType, copyProps, copyRefs){
+	if (entity === null || entity === undefined) {
+		return NewEntity();
+	}
+	let newEntity = NewEntity();
+	SetId(newEntity, GetId(entity));
+	SetDeleted(newEntity, GetDeleted(entity));
+	if (addType){
+		let rdf = GetNamespacePrefix("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+		let type = GetReference(entity, rdf, "type");
+		if (type != null){
+			AddReference(newEntity, rdf, "type", type)
+		}
+	}
+	if (copyProps) {
+		for (const [key, value] of Object.entries(entity["Properties"])) {
+			newEntity["Properties"][key] = value;
+		}
+	}
+	if (copyRefs) {
+		for (const [key, value] of Object.entries(entity["References"])) {
+			newEntity["References"][key] = value;
+		}
+	}
+	return newEntity;
+}
+`

--- a/pkg/transform/runtime.go
+++ b/pkg/transform/runtime.go
@@ -1,0 +1,186 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/gofrs/uuid"
+
+	"github.com/mimiro-io/datahub-cli/pkg/api"
+)
+
+type transformer struct {
+	query            *queryClient
+	assertedPrefixes map[string]string
+	logs             *logCollector
+}
+
+func newTransformer(hubURL, bearer string, logs *logCollector) *transformer {
+	asserted := make(map[string]string)
+	if hubURL != "" {
+		if ns, err := fetchNamespaces(hubURL, bearer); err == nil {
+			for prefix, expansion := range ns {
+				asserted[expansion] = prefix
+			}
+		}
+	}
+	return &transformer{
+		query:            newQueryClient(hubURL, bearer),
+		assertedPrefixes: asserted,
+		logs:             logs,
+	}
+}
+
+func hookEngine(engine *goja.Runtime, tf *transformer) {
+	engine.Set("Query", tf.Query)
+	engine.Set("FindById", tf.ById)
+	engine.Set("GetNamespacePrefix", tf.GetNamespacePrefix)
+	engine.Set("AssertNamespacePrefix", tf.AssertNamespacePrefix)
+	engine.Set("Log", tf.Log)
+	engine.Set("NewEntity", tf.NewEntity)
+	engine.Set("IsValidEntity", tf.IsValidEntity)
+	engine.Set("ToString", tf.ToString)
+	engine.Set("AsEntity", tf.AsEntity)
+	engine.Set("UUID", tf.UUID)
+}
+
+func (tf *transformer) Log(thing interface{}, logLevel string) {
+	level := strings.ToLower(logLevel)
+	switch level {
+	case "info", "warn", "warning", "err", "error":
+	default:
+		level = "info"
+	}
+	if level == "warning" {
+		level = "warn"
+	}
+	if level == "err" {
+		level = "error"
+	}
+	tf.logs.add(LogEntry{
+		Level:     level,
+		Message:   fmt.Sprintf("%v", thing),
+		Timestamp: time.Now(),
+	})
+}
+
+func (tf *transformer) UUID() string {
+	uid, _ := uuid.NewV4()
+	return uid.String()
+}
+
+func (tf *transformer) GetNamespacePrefix(urlExpansion string) string {
+	prefix, err := tf.query.GetNamespacePrefix(urlExpansion)
+	if err != nil {
+		// 404 → fall back to ns0, matching internal/transform behaviour.
+		if strings.Contains(err.Error(), "404") {
+			return "ns0"
+		}
+		tf.logs.add(LogEntry{
+			Level:     "error",
+			Message:   fmt.Sprintf("GetNamespacePrefix(%q): %s", urlExpansion, err.Error()),
+			Timestamp: time.Now(),
+		})
+		return ""
+	}
+	return prefix
+}
+
+func (tf *transformer) AssertNamespacePrefix(urlExpansion string) string {
+	if val, ok := tf.assertedPrefixes[urlExpansion]; ok {
+		return val
+	}
+	prefix := "ns" + strconv.Itoa(len(tf.assertedPrefixes))
+	tf.assertedPrefixes[urlExpansion] = prefix
+	return prefix
+}
+
+func (tf *transformer) Query(startingEntities []string, predicate string, inverse bool, datasets []string) [][]interface{} {
+	result, err := tf.query.Query(startingEntities, predicate, inverse, datasets)
+	if err != nil {
+		tf.logs.add(LogEntry{
+			Level:     "error",
+			Message:   fmt.Sprintf("Query: %s", err.Error()),
+			Timestamp: time.Now(),
+		})
+		return nil
+	}
+	out := make([][]interface{}, len(result))
+	for i, r := range result {
+		out[i] = []interface{}{r.Uri, r.PredicateUri, r.Entity}
+	}
+	return out
+}
+
+func (tf *transformer) ById(entityId string, datasets []string) *api.Entity {
+	entity, err := tf.query.QuerySingle(entityId, datasets)
+	if err != nil {
+		tf.logs.add(LogEntry{
+			Level:     "error",
+			Message:   fmt.Sprintf("FindById(%q): %s", entityId, err.Error()),
+			Timestamp: time.Now(),
+		})
+		return nil
+	}
+	return entity
+}
+
+func (tf *transformer) NewEntity() *api.Entity {
+	return &api.Entity{
+		References: map[string]interface{}{},
+		Properties: map[string]interface{}{},
+	}
+}
+
+func (tf *transformer) ToString(obj interface{}) string {
+	if obj == nil {
+		return "undefined"
+	}
+	switch obj.(type) {
+	case *api.Entity:
+		return fmt.Sprintf("%v", obj)
+	case map[string]interface{}:
+		return fmt.Sprintf("%v", obj)
+	case int, int32, int64:
+		return fmt.Sprintf("%d", obj)
+	case float32, float64:
+		return fmt.Sprintf("%g", obj)
+	case bool:
+		return fmt.Sprintf("%v", obj)
+	default:
+		return fmt.Sprintf("%s", obj)
+	}
+}
+
+func (tf *transformer) IsValidEntity(entity *api.Entity) bool {
+	if entity == nil {
+		return false
+	}
+	return entity.Recorded != 0
+}
+
+func (tf *transformer) AsEntity(val interface{}) (res *api.Entity) {
+	if e, ok := val.(*api.Entity); ok {
+		return e
+	}
+	if m, ok := val.(map[string]interface{}); ok {
+		defer func() {
+			if recover() != nil {
+				res = nil
+			}
+		}()
+		return api.NewEntityFromMap(m)
+	}
+	return nil
+}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -1,0 +1,180 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+// Package transform runs MIMIRO transform scripts (TypeScript or JavaScript)
+// against a hub via esbuild + goja.
+package transform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dop251/goja"
+
+	"github.com/mimiro-io/datahub-cli/pkg/api"
+)
+
+type Logger interface {
+	Log(entry LogEntry)
+}
+
+type LogEntry struct {
+	Level     string    `json:"level"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"ts"`
+}
+
+type Options struct {
+	HubURL  string
+	Bearer  string
+	Logger  Logger
+	Timeout time.Duration
+}
+
+// Compile and runtime errors surface as level=error entries on Logs with
+// empty Entities; the error return is reserved for cancellation / timeout.
+type Result struct {
+	Entities   []*api.Entity `json:"entities"`
+	Logs       []LogEntry    `json:"logs"`
+	DurationMs int64         `json:"durationMs"`
+}
+
+func Run(ctx context.Context, source string, entities []*api.Entity, opts Options) (*Result, error) {
+	start := time.Now()
+	res := &Result{
+		Entities: []*api.Entity{},
+		Logs:     []LogEntry{},
+	}
+
+	collector := &logCollector{logger: opts.Logger, entries: []LogEntry{}}
+
+	code, compileErr := compile(source)
+	if compileErr != nil {
+		collector.add(LogEntry{
+			Level:     "error",
+			Message:   compileErr.Error(),
+			Timestamp: time.Now(),
+		})
+		res.Logs = collector.entries
+		res.DurationMs = time.Since(start).Milliseconds()
+		return res, nil
+	}
+
+	tf := newTransformer(opts.HubURL, opts.Bearer, collector)
+	engine := goja.New()
+	hookEngine(engine, tf)
+
+	// Helpers must load before user code: the namespace shim emitted by
+	// compile() captures helper references eagerly via object-literal binding.
+	if _, err := engine.RunString(helperJavascriptFunctions); err != nil {
+		return nil, fmt.Errorf("install helpers: %w", err)
+	}
+
+	if _, err := engine.RunString(code); err != nil {
+		collector.add(LogEntry{
+			Level:     "error",
+			Message:   fmt.Sprintf("script load: %s", err.Error()),
+			Timestamp: time.Now(),
+		})
+		res.Logs = collector.entries
+		res.DurationMs = time.Since(start).Milliseconds()
+		return res, nil
+	}
+	if _, err := engine.RunString(wrapperJavascriptFunction); err != nil {
+		return nil, fmt.Errorf("install wrapper: %w", err)
+	}
+
+	runCtx := ctx
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	out, runErr := transformEntities(runCtx, engine, entities)
+	if runErr != nil {
+		if errors.Is(runErr, context.DeadlineExceeded) || errors.Is(runErr, context.Canceled) {
+			return nil, runErr
+		}
+		collector.add(LogEntry{
+			Level:     "error",
+			Message:   runErr.Error(),
+			Timestamp: time.Now(),
+		})
+		res.Logs = collector.entries
+		res.DurationMs = time.Since(start).Milliseconds()
+		return res, nil
+	}
+
+	res.Entities = out
+	res.Logs = collector.entries
+	res.DurationMs = time.Since(start).Milliseconds()
+	return res, nil
+}
+
+func transformEntities(ctx context.Context, engine *goja.Runtime, entities []*api.Entity) ([]*api.Entity, error) {
+	var transFunc func(entities []*api.Entity) (interface{}, error)
+	if err := engine.ExportTo(engine.Get("transform_entities_ex"), &transFunc); err != nil {
+		return nil, fmt.Errorf("export transform_entities: %w", err)
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			engine.Interrupt(ctx.Err())
+		case <-done:
+		}
+	}()
+
+	result, err := transFunc(entities)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, err
+	}
+
+	switch v := result.(type) {
+	case nil:
+		return []*api.Entity{}, nil
+	case []interface{}:
+		out := make([]*api.Entity, 0, len(v))
+		for _, e := range v {
+			ent, ok := e.(*api.Entity)
+			if !ok {
+				return nil, fmt.Errorf("transform_entities returned non-entity element: %T", e)
+			}
+			out = append(out, ent)
+		}
+		return out, nil
+	case []*api.Entity:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("transform_entities returned unsupported type: %T", v)
+	}
+}
+
+// entries is initialised non-nil so a zero-log run marshals to `[]`, not `null`.
+type logCollector struct {
+	logger  Logger
+	entries []LogEntry
+}
+
+func (c *logCollector) add(e LogEntry) {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now()
+	}
+	c.entries = append(c.entries, e)
+	if c.logger != nil {
+		c.logger.Log(e)
+	}
+}

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 MIMIRO AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package transform
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mimiro-io/datahub-cli/pkg/api"
+)
+
+func TestRun_PureTSPassthrough(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			return entities;
+		}
+	`
+	in := []*api.Entity{
+		{ID: "ns0:a", Properties: map[string]any{}, References: map[string]any{}},
+		{ID: "ns0:b", Properties: map[string]any{}, References: map[string]any{}},
+	}
+
+	res, err := Run(context.Background(), src, in, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 2 {
+		t.Fatalf("want 2 entities, got %d", len(res.Entities))
+	}
+	if res.Entities[0].ID != "ns0:a" || res.Entities[1].ID != "ns0:b" {
+		t.Fatalf("wrong order: %+v", res.Entities)
+	}
+}
+
+func TestRun_HelpersInjected(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			let out = [];
+			for (let e of entities) {
+				let n = NewEntity();
+				SetId(n, GetId(e));
+				SetProperty(n, "test", "doubled", (GetProperty(e, "test", "x", 0) as number) * 2);
+				out.push(n);
+			}
+			return out;
+		}
+	`
+	in := []*api.Entity{
+		{ID: "x:1", Properties: map[string]any{"test:x": 5}, References: map[string]any{}},
+	}
+
+	res, err := Run(context.Background(), src, in, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1, got %d", len(res.Entities))
+	}
+	got := res.Entities[0]
+	if got.ID != "x:1" {
+		t.Errorf("ID = %q, want x:1", got.ID)
+	}
+	if v, ok := got.Properties["test:doubled"]; !ok || v != int64(10) {
+		t.Errorf("test:doubled = %v (%T), want 10", v, v)
+	}
+}
+
+func TestRun_LogCapture(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			Log("hello", "info");
+			Log("careful", "warn");
+			Log("oops", "error");
+			return entities;
+		}
+	`
+	res, err := Run(context.Background(), src, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Logs) != 3 {
+		t.Fatalf("want 3 logs, got %d: %+v", len(res.Logs), res.Logs)
+	}
+	want := []struct{ level, msg string }{
+		{"info", "hello"},
+		{"warn", "careful"},
+		{"error", "oops"},
+	}
+	for i, w := range want {
+		if res.Logs[i].Level != w.level || res.Logs[i].Message != w.msg {
+			t.Errorf("Logs[%d] = %+v, want %s/%s", i, res.Logs[i], w.level, w.msg)
+		}
+	}
+}
+
+func TestRun_CompileErrorBecomesLogEntry(t *testing.T) {
+	src := `function transform_entities(entities`
+	res, err := Run(context.Background(), src, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run returned error (should surface compile errors as log entries): %v", err)
+	}
+	if len(res.Entities) != 0 {
+		t.Errorf("want empty Entities on compile failure, got %d", len(res.Entities))
+	}
+	if len(res.Logs) == 0 || res.Logs[0].Level != "error" {
+		t.Fatalf("want an error log entry, got %+v", res.Logs)
+	}
+}
+
+func TestRun_RuntimeErrorBecomesLogEntry(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			throw new Error("boom");
+		}
+	`
+	res, err := Run(context.Background(), src, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 0 {
+		t.Errorf("want empty Entities on runtime failure, got %d", len(res.Entities))
+	}
+	if len(res.Logs) == 0 || res.Logs[0].Level != "error" {
+		t.Fatalf("want runtime error in logs, got %+v", res.Logs)
+	}
+	if !strings.Contains(res.Logs[0].Message, "boom") {
+		t.Errorf("log = %q, want it to contain 'boom'", res.Logs[0].Message)
+	}
+}
+
+func TestRun_ContextCancellationInterrupts(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			while (true) {}
+		}
+	`
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := Run(ctx, src, nil, Options{})
+	if err == nil {
+		t.Fatal("want context error, got nil")
+	}
+	if err != context.DeadlineExceeded && !strings.Contains(err.Error(), "context") {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestRun_TimeoutOptionInterrupts(t *testing.T) {
+	src := `
+		function transform_entities(entities: any[]) {
+			while (true) {}
+		}
+	`
+	_, err := Run(context.Background(), src, nil, Options{Timeout: 100 * time.Millisecond})
+	if err == nil {
+		t.Fatal("want timeout error, got nil")
+	}
+	if err != context.DeadlineExceeded {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// Regression: Result.Logs/Entities must marshal to `[]`, not `null`.
+func TestRun_LogsAndEntitiesNeverNilOnSuccess(t *testing.T) {
+	src := `function transform_entities(entities) { return entities; }`
+	res, err := Run(context.Background(), src, []*api.Entity{}, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Logs == nil {
+		t.Errorf("Result.Logs is nil; want empty slice (would marshal to JSON null)")
+	}
+	if res.Entities == nil {
+		t.Errorf("Result.Entities is nil; want empty slice")
+	}
+}
+
+func TestRun_ExternalLoggerDualWrite(t *testing.T) {
+	var captured []LogEntry
+	logger := loggerFunc(func(e LogEntry) { captured = append(captured, e) })
+
+	src := `function transform_entities(entities: any[]) { Log("x", "info"); return entities; }`
+	res, err := Run(context.Background(), src, nil, Options{Logger: logger})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Logs) != 1 || len(captured) != 1 {
+		t.Fatalf("want 1 in both, got Result.Logs=%d external=%d", len(res.Logs), len(captured))
+	}
+}
+
+type loggerFunc func(LogEntry)
+
+func (f loggerFunc) Log(e LogEntry) { f(e) }


### PR DESCRIPTION
Exposes Run(ctx, source, entities, opts) which compiles TS/JS via esbuild,
  executes transform_entities() in goja with the same host functions and JS
  helpers the production hub registers, and returns entities + captured logs.

  Self-contained — no dependency on internal/* — so external consumers can
  import it without pulling in CLI internals. The existing mim transform test
  command continues to use internal/transform/ unchanged.

  Notable details:
  - esbuild Transform output has top-level import/export stripped before handing to goja, since goja treats them as reserved-word syntax errors.
  - `import * as dh from "datahub-tslib"` namespace aliases are resolved by emitting a shim object that binds every host fn + helper as a property.
  - Result.Logs/Entities are always non-nil so JSON marshals to `[]` not `null` for downstream JS consumers.
  - ctx cancellation and Options.Timeout both interrupt long-running scripts via engine.Interrupt