### PR TITLE
feat(transform): SyntheticProvider hook + inputs-aware Query/FindById

### DIFF
--- a/pkg/transform/runtime.go
+++ b/pkg/transform/runtime.go
@@ -24,9 +24,18 @@ type transformer struct {
 	query            *queryClient
 	assertedPrefixes map[string]string
 	logs             *logCollector
+	recorder         QueryRecorder
+	resolver         OverlayResolver
+	synthetics       SyntheticProvider
+	// inputs indexes the entities slice passed to Run so Query/FindById can
+	// consult the user's working set before falling through to synthetics or
+	// the hub. This lets a transform run end-to-end even when the source
+	// entity isn't on the hub yet (a common case during operator scratchpad
+	// work).
+	inputs map[string]*api.Entity
 }
 
-func newTransformer(hubURL, bearer string, logs *logCollector) *transformer {
+func newTransformer(hubURL, bearer string, logs *logCollector, recorder QueryRecorder, resolver OverlayResolver, synthetics SyntheticProvider, inputs []*api.Entity) *transformer {
 	asserted := make(map[string]string)
 	if hubURL != "" {
 		if ns, err := fetchNamespaces(hubURL, bearer); err == nil {
@@ -35,10 +44,20 @@ func newTransformer(hubURL, bearer string, logs *logCollector) *transformer {
 			}
 		}
 	}
+	idx := make(map[string]*api.Entity, len(inputs))
+	for _, e := range inputs {
+		if e != nil && e.ID != "" {
+			idx[e.ID] = e
+		}
+	}
 	return &transformer{
 		query:            newQueryClient(hubURL, bearer),
 		assertedPrefixes: asserted,
 		logs:             logs,
+		recorder:         recorder,
+		resolver:         resolver,
+		synthetics:       synthetics,
+		inputs:           idx,
 	}
 }
 
@@ -107,23 +126,207 @@ func (tf *transformer) AssertNamespacePrefix(urlExpansion string) string {
 }
 
 func (tf *transformer) Query(startingEntities []string, predicate string, inverse bool, datasets []string) [][]interface{} {
-	result, err := tf.query.Query(startingEntities, predicate, inverse, datasets)
-	if err != nil {
+	result, hubErr := tf.query.Query(startingEntities, predicate, inverse, datasets)
+	out := make([][]interface{}, 0)
+	recorded := make([]*api.Entity, 0)
+	seen := make(map[string]struct{})
+
+	if hubErr == nil {
+		for _, r := range result {
+			entity := tf.applyOverlay(r.Entity)
+			out = append(out, []interface{}{r.Uri, r.PredicateUri, entity})
+			if entity != nil {
+				recorded = append(recorded, entity)
+				seen[queryTupleKey(r.Uri, entity.ID)] = struct{}{}
+			}
+		}
+	}
+
+	pool := tf.candidatePool(datasets)
+	starting := make(map[string]struct{}, len(startingEntities))
+	for _, s := range startingEntities {
+		starting[s] = struct{}{}
+	}
+
+	if !inverse {
+		for _, startId := range startingEntities {
+			src, ok := pool[startId]
+			if !ok || src == nil || src.References == nil {
+				continue
+			}
+			refVal, refOK := src.References[predicate]
+			if !refOK {
+				continue
+			}
+			for _, targetId := range refValueToStrings(refVal) {
+				key := queryTupleKey(startId, targetId)
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				tgt := tf.resolveTarget(targetId, datasets)
+				if tgt == nil {
+					continue
+				}
+				tgt = tf.applyOverlay(tgt)
+				if tgt == nil {
+					continue
+				}
+				out = append(out, []interface{}{startId, predicate, tgt})
+				recorded = append(recorded, tgt)
+				seen[key] = struct{}{}
+			}
+		}
+	} else {
+		for _, cand := range pool {
+			if cand == nil || cand.References == nil {
+				continue
+			}
+			refVal, refOK := cand.References[predicate]
+			if !refOK {
+				continue
+			}
+			for _, targetId := range refValueToStrings(refVal) {
+				if _, isStart := starting[targetId]; !isStart {
+					continue
+				}
+				key := queryTupleKey(targetId, cand.ID)
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				resolved := tf.applyOverlay(cand)
+				if resolved == nil {
+					continue
+				}
+				out = append(out, []interface{}{targetId, predicate, resolved})
+				recorded = append(recorded, resolved)
+				seen[key] = struct{}{}
+				break
+			}
+		}
+	}
+
+	// Surface the hub failure only when augmentation didn't rescue the call.
+	// If inputs/synthetics produced tuples, the operator authored a mock on
+	// purpose — the run is succeeding by design and a warn would be friction.
+	if hubErr != nil && len(out) == 0 {
 		tf.logs.add(LogEntry{
-			Level:     "error",
-			Message:   fmt.Sprintf("Query: %s", err.Error()),
+			Level:     "warn",
+			Message:   fmt.Sprintf("Query: hub returned %q; no inputs/synthetics matched", hubErr.Error()),
 			Timestamp: time.Now(),
 		})
-		return nil
 	}
-	out := make([][]interface{}, len(result))
-	for i, r := range result {
-		out[i] = []interface{}{r.Uri, r.PredicateUri, r.Entity}
-	}
+
+	tf.recordQuery(QueryRecord{
+		Kind:        "query",
+		StartingIds: startingEntities,
+		Predicate:   predicate,
+		Inverse:     inverse,
+		Datasets:    datasets,
+		Entities:    recorded,
+	})
 	return out
 }
 
+// candidatePool merges the input working set (always — inputs have no dataset
+// tag) with synthetics filtered by the datasets argument. The returned map is
+// keyed by entity id; on collision the synthetic wins, since the operator has
+// explicitly authored it as the source of truth.
+func (tf *transformer) candidatePool(datasets []string) map[string]*api.Entity {
+	pool := make(map[string]*api.Entity, len(tf.inputs))
+	for id, e := range tf.inputs {
+		pool[id] = e
+	}
+	if tf.synthetics != nil {
+		for _, syn := range tf.synthetics.All(datasets) {
+			if syn != nil && syn.ID != "" {
+				pool[syn.ID] = syn
+			}
+		}
+	}
+	return pool
+}
+
+// resolveTarget walks inputs → synthetics → hub. Used by Query forward
+// augmentation when chasing a ref target out of the user's working set.
+func (tf *transformer) resolveTarget(id string, datasets []string) *api.Entity {
+	if e, ok := tf.inputs[id]; ok {
+		return e
+	}
+	if tf.synthetics != nil {
+		if syn := tf.synthetics.Lookup(id, datasets); syn != nil {
+			return syn
+		}
+	}
+	if e, err := tf.query.QuerySingle(id, datasets); err == nil && e != nil {
+		return e
+	}
+	return nil
+}
+
+func queryTupleKey(subject, target string) string {
+	return subject + "\x00" + target
+}
+
+func refValueToStrings(v interface{}) []string {
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, x := range t {
+			if s, ok := x.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(t))
+		for _, s := range t {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 func (tf *transformer) ById(entityId string, datasets []string) *api.Entity {
+	// Inputs win — the user's working set is in scope even when no hub-side
+	// representation exists yet. Dataset filter doesn't apply to inputs
+	// (they aren't tagged with a dataset).
+	if e, ok := tf.inputs[entityId]; ok {
+		entity := tf.applyOverlay(e)
+		if entity != nil {
+			tf.recordQuery(QueryRecord{
+				Kind:        "findById",
+				StartingIds: []string{entityId},
+				Datasets:    datasets,
+				Entities:    []*api.Entity{entity},
+			})
+		}
+		return entity
+	}
+	// Synthetic mocks take precedence over the hub — operators author them to
+	// short-circuit a real lookup (typically because the dataset doesn't exist
+	// on the hub yet).
+	if tf.synthetics != nil {
+		if syn := tf.synthetics.Lookup(entityId, datasets); syn != nil {
+			syn = tf.applyOverlay(syn)
+			if syn != nil {
+				tf.recordQuery(QueryRecord{
+					Kind:        "findById",
+					StartingIds: []string{entityId},
+					Datasets:    datasets,
+					Entities:    []*api.Entity{syn},
+				})
+			}
+			return syn
+		}
+	}
 	entity, err := tf.query.QuerySingle(entityId, datasets)
 	if err != nil {
 		tf.logs.add(LogEntry{
@@ -133,7 +336,33 @@ func (tf *transformer) ById(entityId string, datasets []string) *api.Entity {
 		})
 		return nil
 	}
+	entity = tf.applyOverlay(entity)
+	if entity != nil {
+		tf.recordQuery(QueryRecord{
+			Kind:        "findById",
+			StartingIds: []string{entityId},
+			Datasets:    datasets,
+			Entities:    []*api.Entity{entity},
+		})
+	}
 	return entity
+}
+
+func (tf *transformer) applyOverlay(e *api.Entity) *api.Entity {
+	if tf.resolver == nil || e == nil {
+		return e
+	}
+	if merged := tf.resolver.ResolveOverlay(e); merged != nil {
+		return merged
+	}
+	return e
+}
+
+func (tf *transformer) recordQuery(record QueryRecord) {
+	if tf.recorder == nil {
+		return
+	}
+	tf.recorder.RecordQuery(record)
 }
 
 func (tf *transformer) NewEntity() *api.Entity {

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -36,6 +36,59 @@ type Options struct {
 	Bearer  string
 	Logger  Logger
 	Timeout time.Duration
+
+	// All three nil in production. The operator UI uses QueryRecorder to
+	// discover what a transform pulled in via Query/FindById, OverlayResolver
+	// to substitute mocked entity fields before user code observes them, and
+	// SyntheticProvider to inject user-authored mock entities into FindById /
+	// Query results when the hub itself wouldn't surface them.
+	QueryRecorder     QueryRecorder
+	OverlayResolver   OverlayResolver
+	SyntheticProvider SyntheticProvider
+}
+
+// QueryRecorder observes the entities surfaced through Query / FindById, in
+// the order they reach user code (i.e. after OverlayResolver has run).
+type QueryRecorder interface {
+	RecordQuery(record QueryRecord)
+}
+
+type QueryRecord struct {
+	Kind        string        // "query" | "findById"
+	StartingIds []string
+	Predicate   string
+	Inverse     bool
+	Datasets    []string
+	Entities    []*api.Entity
+}
+
+// OverlayResolver gets a shot at every entity emerging from Query / FindById
+// before it reaches user code. Implementations return the entity to hand on —
+// either the original or a (cloned and) mutated version. Returning nil signals
+// "no overlay; use the original".
+type OverlayResolver interface {
+	ResolveOverlay(e *api.Entity) *api.Entity
+}
+
+// SyntheticProvider injects user-authored mock entities into the runtime.
+//
+// Lookup is called by tf.ById and the cli's Query-augmentation path to resolve
+// a specific id against the operator's authored mocks. If a synthetic exists
+// with that id (and a matching dataset, when the call passes a non-empty
+// datasets filter), it stands in for any hub result. The synthetic is then
+// run through OverlayResolver just like a hub entity would be, so pinned
+// overrides still apply.
+//
+// All returns every synthetic that passes the datasets filter — used by the
+// cli's Query augmentation to walk the candidate pool for inverse lookups
+// (entities whose refs[predicate] points at one of the startingIds) and as
+// the fallback target pool when the hub returns no tuples.
+//
+// The datasets slice is honoured in both methods: when non-empty, the
+// synthetic's dataset must appear in the slice to participate.
+type SyntheticProvider interface {
+	Lookup(id string, datasets []string) *api.Entity
+	All(datasets []string) []*api.Entity
 }
 
 // Compile and runtime errors surface as level=error entries on Logs with
@@ -67,7 +120,7 @@ func Run(ctx context.Context, source string, entities []*api.Entity, opts Option
 		return res, nil
 	}
 
-	tf := newTransformer(opts.HubURL, opts.Bearer, collector)
+	tf := newTransformer(opts.HubURL, opts.Bearer, collector, opts.QueryRecorder, opts.OverlayResolver, opts.SyntheticProvider, entities)
 	engine := goja.New()
 	hookEngine(engine, tf)
 

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -10,7 +10,11 @@ package transform
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -201,3 +205,644 @@ func TestRun_ExternalLoggerDualWrite(t *testing.T) {
 type loggerFunc func(LogEntry)
 
 func (f loggerFunc) Log(e LogEntry) { f(e) }
+
+// stubHub serves the minimal /namespaces and /query endpoints the transform
+// runtime calls. /query inspects the request body to dispatch between the
+// graph-style Query (startingEntities + predicate) and the single-entity
+// FindById path.
+func stubHub(t *testing.T, hits map[string][]queryResultPart, single map[string]*api.Entity) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/namespaces", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{})
+	})
+	mux.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if id, ok := body["entityId"].(string); ok {
+			ent, found := single[id]
+			if !found {
+				http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]any{map[string]any{"id": "@context"}, ent})
+			return
+		}
+		startersRaw, _ := body["startingEntities"].([]any)
+		key := ""
+		if len(startersRaw) > 0 {
+			key, _ = startersRaw[0].(string)
+		}
+		parts := hits[key]
+		tuples := make([]any, len(parts))
+		for i, p := range parts {
+			tuples[i] = []any{p.Uri, p.PredicateUri, p.Entity}
+		}
+		raw, _ := json.Marshal(tuples)
+		_, _ = w.Write([]byte(`[{},` + string(raw) + `]`))
+	})
+	return httptest.NewServer(mux)
+}
+
+type recorderStub struct {
+	mu      sync.Mutex
+	records []QueryRecord
+}
+
+func (r *recorderStub) RecordQuery(rec QueryRecord) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, rec)
+}
+
+type resolverFunc func(*api.Entity) *api.Entity
+
+func (f resolverFunc) ResolveOverlay(e *api.Entity) *api.Entity { return f(e) }
+
+func TestRun_QueryRecorderObservesCalls(t *testing.T) {
+	hits := map[string][]queryResultPart{
+		"ns0:src": {{
+			Uri:          "ns0:src",
+			PredicateUri: "ns0:hasFoo",
+			Entity: &api.Entity{
+				ID:         "ns0:target",
+				Properties: map[string]any{"ns0:flag": false},
+				References: map[string]any{},
+			},
+		}},
+	}
+	srv := stubHub(t, hits, nil)
+	defer srv.Close()
+
+	rec := &recorderStub{}
+	src := `
+		function transform_entities(entities: any[]) {
+			let hits = Query(["ns0:src"], "ns0:hasFoo", false, []);
+			return entities;
+		}
+	`
+	_, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:x", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, QueryRecorder: rec})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rec.records) != 1 {
+		t.Fatalf("want 1 recorded call, got %d", len(rec.records))
+	}
+	got := rec.records[0]
+	if got.Kind != "query" || got.Predicate != "ns0:hasFoo" {
+		t.Errorf("record kind/predicate = %s/%s, want query/ns0:hasFoo", got.Kind, got.Predicate)
+	}
+	if len(got.Entities) != 1 || got.Entities[0].ID != "ns0:target" {
+		t.Errorf("record entities = %+v, want [ns0:target]", got.Entities)
+	}
+}
+
+func TestRun_OverlayResolverMutatesQueryEntity(t *testing.T) {
+	hits := map[string][]queryResultPart{
+		"ns0:src": {{
+			Uri:          "ns0:src",
+			PredicateUri: "ns0:hasFoo",
+			Entity: &api.Entity{
+				ID:         "ns0:target",
+				Properties: map[string]any{"ns0:flag": false},
+				References: map[string]any{},
+			},
+		}},
+	}
+	srv := stubHub(t, hits, nil)
+	defer srv.Close()
+
+	resolver := resolverFunc(func(e *api.Entity) *api.Entity {
+		if e == nil || e.ID != "ns0:target" {
+			return e
+		}
+		clone := *e
+		clone.Properties = make(map[string]any, len(e.Properties))
+		for k, v := range e.Properties {
+			clone.Properties[k] = v
+		}
+		clone.Properties["ns0:flag"] = true
+		return &clone
+	})
+
+	src := `
+		function transform_entities(entities: any[]) {
+			let hits = Query(["ns0:src"], "ns0:hasFoo", false, []);
+			let target = hits[0][2];
+			let out = NewEntity();
+			SetId(out, GetId(entities[0]));
+			SetProperty(out, "ns0", "flagged", GetProperty(target, "ns0", "flag", false));
+			return [out];
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:x", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, OverlayResolver: resolver})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 entity, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	got := res.Entities[0]
+	if v, ok := got.Properties["ns0:flagged"]; !ok || v != true {
+		t.Errorf("overlay didn't reach transform: ns0:flagged = %v", v)
+	}
+}
+
+type syntheticStub struct {
+	entities map[string]syntheticEntry
+}
+
+type syntheticEntry struct {
+	dataset string
+	entity  *api.Entity
+}
+
+func (s *syntheticStub) Lookup(id string, datasets []string) *api.Entity {
+	e, ok := s.entities[id]
+	if !ok {
+		return nil
+	}
+	if !syntheticDatasetAllowed(e.dataset, datasets) {
+		return nil
+	}
+	clone := *e.entity
+	return &clone
+}
+
+func (s *syntheticStub) All(datasets []string) []*api.Entity {
+	var out []*api.Entity
+	for _, e := range s.entities {
+		if !syntheticDatasetAllowed(e.dataset, datasets) {
+			continue
+		}
+		clone := *e.entity
+		out = append(out, &clone)
+	}
+	return out
+}
+
+func syntheticDatasetAllowed(have string, filter []string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for _, d := range filter {
+		if d == have {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRun_FindByIdReturnsSyntheticWhenHubEmpty(t *testing.T) {
+	srv := stubHub(t, nil, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID:         "ns0:Mock-1",
+				Properties: map[string]any{"ns0:flag": true},
+				References: map[string]any{},
+			},
+		},
+	}}
+	rec := &recorderStub{}
+	src := `
+		function transform_entities(entities: any[]) {
+			let mock = FindById("ns0:Mock-1", []);
+			if (mock === null) { Log("missing", "error"); return entities; }
+			let out = NewEntity();
+			SetId(out, "ns0:result");
+			SetProperty(out, "ns0", "flag", GetProperty(mock, "ns0", "flag", false));
+			return [out];
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov, QueryRecorder: rec})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 result, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	if v := res.Entities[0].Properties["ns0:flag"]; v != true {
+		t.Errorf("flag = %v, want true (synthetic should be visible to transform)", v)
+	}
+	if len(rec.records) != 1 || rec.records[0].Kind != "findById" {
+		t.Errorf("recorder: want one findById entry, got %+v", rec.records)
+	}
+}
+
+func TestRun_FindByIdRespectsDatasetFilterOnSynthetic(t *testing.T) {
+	srv := stubHub(t, nil, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID: "ns0:Mock-1", Properties: map[string]any{}, References: map[string]any{},
+			},
+		},
+	}}
+	src := `
+		function transform_entities(entities: any[]) {
+			let m = FindById("ns0:Mock-1", ["ns0.OtherDb"]);
+			Log(m === null ? "miss" : "hit", "info");
+			return entities;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Filter doesn't include the synthetic's dataset → synthetic doesn't fire,
+	// hub stub returns 404 → FindById logs an error and returns null.
+	found := false
+	for _, l := range res.Logs {
+		if l.Level == "info" && l.Message == "miss" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a 'miss' info log, got %+v", res.Logs)
+	}
+}
+
+func TestRun_QueryForwardEmitsSyntheticAsStartingPoint(t *testing.T) {
+	// Hub stub returns no tuples for ns0:Mock-1 — the only path that surfaces
+	// a target entity is through the synthetic provider.
+	hits := map[string][]queryResultPart{}
+	single := map[string]*api.Entity{
+		"ns0:Herd-A": {
+			ID:         "ns0:Herd-A",
+			Properties: map[string]any{"ns0:name": "alpha"},
+			References: map[string]any{},
+		},
+	}
+	srv := stubHub(t, hits, single)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID:         "ns0:Mock-1",
+				Properties: map[string]any{},
+				References: map[string]any{"ns0:hasHerd": "ns0:Herd-A"},
+			},
+		},
+	}}
+	src := `
+		function transform_entities(entities: any[]) {
+			let hits = Query(["ns0:Mock-1"], "ns0:hasHerd", false, []);
+			let out: any[] = [];
+			for (let h of hits) {
+				let target = h[2];
+				if (target !== null && target !== undefined) {
+					let e = NewEntity();
+					SetId(e, "ns0:row");
+					SetProperty(e, "ns0", "subject", h[0]);
+					SetProperty(e, "ns0", "name", GetProperty(target, "ns0", "name", ""));
+					out.push(e);
+				}
+			}
+			return out;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 result tuple, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	got := res.Entities[0]
+	if v := got.Properties["ns0:subject"]; v != "ns0:Mock-1" {
+		t.Errorf("subject = %v, want ns0:Mock-1", v)
+	}
+	if v := got.Properties["ns0:name"]; v != "alpha" {
+		t.Errorf("name = %v, want alpha (target resolved through hub)", v)
+	}
+}
+
+func TestRun_QueryInverseEmitsSyntheticAsTarget(t *testing.T) {
+	srv := stubHub(t, nil, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID:         "ns0:Mock-1",
+				Properties: map[string]any{"ns0:name": "beta"},
+				References: map[string]any{"ns0:knows": "ns0:Animal-X"},
+			},
+		},
+	}}
+	src := `
+		function transform_entities(entities: any[]) {
+			let hits = Query(["ns0:Animal-X"], "ns0:knows", true, []);
+			let out: any[] = [];
+			for (let h of hits) {
+				let target = h[2];
+				if (target !== null && target !== undefined) {
+					let e = NewEntity();
+					SetId(e, "ns0:row");
+					SetProperty(e, "ns0", "found", GetProperty(target, "ns0", "name", ""));
+					out.push(e);
+				}
+			}
+			return out;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 result, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	if v := res.Entities[0].Properties["ns0:found"]; v != "beta" {
+		t.Errorf("found = %v, want beta", v)
+	}
+}
+
+func TestRun_QueryDatasetFilterDropsMismatchedSynthetics(t *testing.T) {
+	srv := stubHub(t, nil, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID:         "ns0:Mock-1",
+				Properties: map[string]any{},
+				References: map[string]any{"ns0:rel": "ns0:Anything"},
+			},
+		},
+	}}
+	src := `
+		function transform_entities(entities: any[]) {
+			let hits = Query(["ns0:Mock-1"], "ns0:rel", false, ["ns0.OtherDb"]);
+			Log("count " + hits.length, "info");
+			return entities;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := "count 0"
+	found := false
+	for _, l := range res.Logs {
+		if l.Level == "info" && l.Message == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want a %q info log (filter should drop synthetic), got %+v", want, res.Logs)
+	}
+}
+
+// stubHubQuery500 mirrors stubHub but the /query endpoint returns 500 for
+// non-entityId calls — this reproduces the "could not load predicate id" path
+// the hub takes when an operator's transform names a predicate the hub
+// doesn't have registered yet.
+func stubHubQuery500(t *testing.T, single map[string]*api.Entity) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/namespaces", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{})
+	})
+	mux.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if id, ok := body["entityId"].(string); ok {
+			ent, found := single[id]
+			if !found {
+				http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]any{map[string]any{"id": "@context"}, ent})
+			return
+		}
+		http.Error(w, `{"message":"could not load predicate id"}`, http.StatusInternalServerError)
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestRun_QueryHubErrorWithInputSourceFindsSyntheticTarget reproduces the
+// reported bug: a transform runs with a real-looking input entity whose
+// refs[predicate] points at a synthetic entity, but the hub doesn't recognise
+// the predicate and returns 500. The cli should downgrade the failure to a
+// warning, walk the input's refs, and emit the synthetic as the tuple target.
+func TestRun_QueryHubErrorWithInputSourceFindsSyntheticTarget(t *testing.T) {
+	srv := stubHubQuery500(t, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns823:1000": {
+			dataset: "raavaretorget.Anmerkningene",
+			entity: &api.Entity{
+				ID: "ns823:1000",
+				Properties: map[string]any{
+					"ns823:id":   900,
+					"ns823:navn": "Hoyt baktfoo",
+				},
+				References: map[string]any{
+					"ns2:type":    "ns361:Anmerkning",
+					"ns823:pred":  "ns825:2680067",
+					"ns823:sameAs": "ns368:900",
+				},
+			},
+		},
+	}}
+
+	input := &api.Entity{
+		ID:       "ns825:2680067",
+		Recorded: 1778688855839914800,
+		Properties: map[string]any{
+			"ns825:id":     2680067,
+			"ns825:mengde": 3519,
+		},
+		References: map[string]any{
+			"ns2:type":            "ns361:Leveranse",
+			"ns825:produsent_id":  "ns824:26003",
+			"ns825:foobar":        "ns823:1000",
+		},
+	}
+	src := `
+		function transform_entities(entities: any[]) {
+			let out: any[] = [];
+			for (let e of entities) {
+				let hits = Query([GetId(e)], "ns825:foobar", false, ["raavaretorget.Leveranse", "raavaretorget.Anmerkningene"]);
+				for (let h of hits) {
+					let target = h[2];
+					if (target !== null && target !== undefined) {
+						let row = NewEntity();
+						SetId(row, "ns:row");
+						SetProperty(row, "ns823", "navn", GetProperty(target, "ns823", "navn", ""));
+						out.push(row);
+					}
+				}
+			}
+			return out;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{input}, Options{
+		HubURL:            srv.URL,
+		SyntheticProvider: prov,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1 result tuple, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	if v := res.Entities[0].Properties["ns823:navn"]; v != "Hoyt baktfoo" {
+		t.Errorf("navn = %v; want 'Hoyt baktfoo' (the synthetic should be visible)", v)
+	}
+	// The hub failure must NOT surface as warn/error when augmentation
+	// rescued the run — the operator authored the synthetic on purpose.
+	for _, l := range res.Logs {
+		if l.Level == "warn" || l.Level == "error" {
+			t.Errorf("expected silent rescue, got %s log: %q", l.Level, l.Message)
+		}
+	}
+}
+
+// Sibling case: hub fails AND no synthetic/input matches. The warn surfaces
+// so the operator sees what happened instead of getting silent zero results.
+func TestRun_QueryHubErrorWithoutAugmentationSurfacesWarn(t *testing.T) {
+	srv := stubHubQuery500(t, nil)
+	defer srv.Close()
+
+	src := `
+		function transform_entities(entities: any[]) {
+			Query(["ns:nothing"], "ns:missing", false, []);
+			return entities;
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	sawWarn := false
+	for _, l := range res.Logs {
+		if l.Level == "warn" && strings.Contains(l.Message, "could not load predicate") {
+			sawWarn = true
+		}
+	}
+	if !sawWarn {
+		t.Errorf("hub failure with no augmentation should surface a warn; got %+v", res.Logs)
+	}
+}
+
+func TestRun_OverlayAppliesOnTopOfSynthetic(t *testing.T) {
+	srv := stubHub(t, nil, nil)
+	defer srv.Close()
+
+	prov := &syntheticStub{entities: map[string]syntheticEntry{
+		"ns0:Mock-1": {
+			dataset: "ns0.MockDb",
+			entity: &api.Entity{
+				ID:         "ns0:Mock-1",
+				Properties: map[string]any{"ns0:flag": false},
+				References: map[string]any{},
+			},
+		},
+	}}
+	resolver := resolverFunc(func(e *api.Entity) *api.Entity {
+		if e == nil || e.ID != "ns0:Mock-1" {
+			return e
+		}
+		clone := *e
+		clone.Properties = map[string]any{"ns0:flag": true}
+		return &clone
+	})
+	src := `
+		function transform_entities(entities: any[]) {
+			let m = FindById("ns0:Mock-1", []);
+			let out = NewEntity();
+			SetId(out, "ns0:result");
+			SetProperty(out, "ns0", "flag", GetProperty(m, "ns0", "flag", false));
+			return [out];
+		}
+	`
+	res, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:src", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, SyntheticProvider: prov, OverlayResolver: resolver})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Entities) != 1 {
+		t.Fatalf("want 1, got %d (logs=%+v)", len(res.Entities), res.Logs)
+	}
+	if v := res.Entities[0].Properties["ns0:flag"]; v != true {
+		t.Errorf("flag = %v; want true (overlay should layer onto synthetic)", v)
+	}
+}
+
+func TestRun_FindByIdHooksFireToo(t *testing.T) {
+	single := map[string]*api.Entity{
+		"ns0:lookup": {
+			ID:         "ns0:lookup",
+			Properties: map[string]any{"ns0:n": 1},
+			References: map[string]any{},
+		},
+	}
+	srv := stubHub(t, nil, single)
+	defer srv.Close()
+
+	rec := &recorderStub{}
+	resolver := resolverFunc(func(e *api.Entity) *api.Entity {
+		if e == nil {
+			return nil
+		}
+		clone := *e
+		clone.Properties = map[string]any{"ns0:n": int64(42)}
+		return &clone
+	})
+	src := `
+		function transform_entities(entities: any[]) {
+			let found = FindById("ns0:lookup", []);
+			return entities;
+		}
+	`
+	_, err := Run(context.Background(), src, []*api.Entity{
+		{ID: "ns0:x", Properties: map[string]any{}, References: map[string]any{}},
+	}, Options{HubURL: srv.URL, QueryRecorder: rec, OverlayResolver: resolver})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rec.records) != 1 || rec.records[0].Kind != "findById" {
+		t.Fatalf("want 1 findById record, got %+v", rec.records)
+	}
+	got := rec.records[0]
+	if len(got.Entities) != 1 || got.Entities[0].Properties["ns0:n"] != int64(42) {
+		t.Errorf("overlay didn't reach recorder; entities=%+v", got.Entities)
+	}
+}


### PR DESCRIPTION
Lets operator UIs inject user-authored mock entities into the goja
  runtime. Production callers pass nil — zero overhead.

  - SyntheticProvider exposes Lookup(id, datasets) and All(datasets). The cli drives forward / inverse matching itself, so adapters stay thin.
  - Run indexes its entities slice into an inputs map so Query and FindById can resolve ids against the user's working set before falling through to synthetics and the hub.
  - Query tolerates hub failures (common case: "could not load predicate id" for a not-yet-registered predicate). On error it still walks inputs ∪ synthetics for forward + inverse augmentation and surfaces a warn only when nothing was rescued.
  - OverlayResolver runs on synthetic entities too, so pinned property / ref overrides layer on top of mocks the same way they do on hub results.